### PR TITLE
chore(yaml): switch to go.yaml.in/yaml/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,5 @@ require (
 	github.com/agilira/go-timecache v1.0.2
 	github.com/agilira/orpheus v1.1.11
 	github.com/mattn/go-sqlite3 v1.14.34
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v3 v3.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -8,7 +8,7 @@ github.com/agilira/orpheus v1.1.11 h1:JhvofX8JokigrywzhK0UN62Jl8HtsodEiR79zSuyXq
 github.com/agilira/orpheus v1.1.11/go.mod h1:a/TfY4gXDb6sTWJDbS4fp1zmykBzyChkgurRVYMeX3w=
 github.com/mattn/go-sqlite3 v1.14.34 h1:3NtcvcUnFBPsuRcno8pUtupspG/GM+9nZ88zgJcp6Zk=
 github.com/mattn/go-sqlite3 v1.14.34/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/parser_structured.go
+++ b/parser_structured.go
@@ -18,7 +18,7 @@ import (
 	"unicode"
 
 	"github.com/agilira/go-errors"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // parseJSON parses JSON configuration with pooled map to reduce allocations.
@@ -71,7 +71,7 @@ func validateJSONKey(key string) error {
 	return nil
 }
 
-// parseYAML parses YAML configuration using gopkg.in/yaml.v3 for full YAML 1.2
+// parseYAML parses YAML configuration using go.yaml.in/yaml/v3 for full YAML 1.2
 // spec compliance. Returns map[string]interface{} for backward compatibility.
 // yaml.v3 handles inline comments, anchors, tags, multiline scalars, and all
 // edge cases that the previous line-by-line parser could not cover.


### PR DESCRIPTION
gopkg.in/yaml.v3 is no longer maintained.

I'm a https://github.com/yaml/go-yaml/ maintainer